### PR TITLE
Fix PAD token loss bug in training

### DIFF
--- a/src/transformer/LtnTransformer.py
+++ b/src/transformer/LtnTransformer.py
@@ -185,7 +185,7 @@ class LtnTransformer(LightningModule):
         self.log("train_loss", loss.item(), on_step=True, on_epoch=False, prog_bar=True, logger=True)
         self.log("train_acc", acc.item(), on_step=True, on_epoch=False, prog_bar=True, logger=True)
 
-        return full_loss
+        return loss
     
     def get_formula_scores(self, 
                          c_formula: ConfigFormula,


### PR DESCRIPTION
- Use PAD-ignoring loss (self.criterion) for backpropagation instead of full_loss
- Keep full_loss only for logging/monitoring purposes
- Aligns with standard LLM training practices where PAD tokens don't contribute to gradients
- Prevents training on meaningless padding positions after EOS tokens

🤖 Generated with [Claude Code](https://claude.ai/code)