### PR TITLE
Implement dynamic batch padding for target sequences

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 from src.formula import create_both_vocabs, FormulaDataset
 from src.transformer import LtnTransformer, create_callbacks, StopAfterDecay
+from src.transformer.helper_functions import dynamic_collate_fn
 from src.ConfigClasses import ConfigFormula, ConfigTransformer
 
 @dataclass
@@ -136,7 +137,14 @@ def main():
                                    configFormula=c_formula,
                                    )
 
-    train_loader = DataLoader(train_dataset, batch_size=config.batch_size, shuffle=False, num_workers=config.num_workers)
+    # Create collate function with PAD token ID
+    collate_fn = lambda batch: dynamic_collate_fn(batch, model.output_vocab.PAD_id)
+
+    train_loader = DataLoader(train_dataset,
+                             batch_size=config.batch_size,
+                             shuffle=False,
+                             num_workers=config.num_workers,
+                             collate_fn=collate_fn)
 
     # Start or resume training
     trainer.fit(model, train_dataloaders=train_loader, ckpt_path=ckpt_path)

--- a/src/formula/Vocabulary.py
+++ b/src/formula/Vocabulary.py
@@ -119,13 +119,10 @@ class Vocabulary:
         token_ids = [self.token_to_id[token] for token in expression if isinstance(token, str)]
         tokenized = torch.tensor(token_ids, dtype=torch.long)
 
-        # Prepare tensor for <PAD> tokens
-        nb_pad_tokens = max(0, configFormula.EXPR_SIZE_MAX - len(tokenized) - 2)  # -2 bc of the SOS and the EOS
-        padding_tokens = torch.full((nb_pad_tokens,), self.PAD_id, dtype=torch.long)
         end_token = torch.tensor([self.token_to_id["<EOS>"]], dtype=torch.long)
 
-        # Combine all parts into one tensor
-        result = torch.cat([start_token, tokenized, end_token, padding_tokens], dim=0)
+        # Combine all parts into one tensor (no padding - will be handled in collate_fn)
+        result = torch.cat([start_token, tokenized, end_token], dim=0)
 
         return result
 


### PR DESCRIPTION
Replace fixed-length padding (EXPR_SIZE_MAX=200) with dynamic padding to the longest sequence in each batch for memory/runtime efficiency.

Changes:
- Remove fixed padding from Vocabulary.tokenize_expr()
- Add dynamic_collate_fn() to helper_functions.py using pad_sequence
- Update train.py DataLoader to use custom collate function with PAD token ID

🤖 Generated with [Claude Code](https://claude.ai/code)